### PR TITLE
Fix hexadecimal string to actually be hexadecimal

### DIFF
--- a/src/underscore.logger.coffee
+++ b/src/underscore.logger.coffee
@@ -50,9 +50,9 @@ class Logger
     result  = ""
     i       = 0
     while color = colors[i]
-      result += "\x33[#{color}m"
+      result += "\x1B[#{color}m"
       i++
-    result += "#{string}\x33[#{Logger.ANSI.OFF}m"
+    result += "#{string}\x1B[#{Logger.ANSI.OFF}m"
     result
   
   format: (date, level, message) ->


### PR DESCRIPTION
Sorry, this was my mistake first time around.

\033 in octal should be \x1B in hexadecimal.
